### PR TITLE
Typo fix Update main.go

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -33,7 +33,7 @@ const timestampFormat = "Mon 02 Jan 2006 3:04:05 PM MST"
 func validateSignedMessage(inp string) (*SignedMessage, error) {
 	var sm SignedMessage
 
-	// Strip newlines form inp
+	// Strip newlines from inp
 	inp = strings.ReplaceAll(inp, "\n", "")
 
 	err := json.Unmarshal([]byte(inp), &sm)


### PR DESCRIPTION
This PR fixes a minor typo in the comment inside the `validateSignedMessage` function.

### **Issue:**

The comment currently reads:

```go
// Strip newlines form inp
```

The word "form" is a typo, and the correct word should be "from."

### **Fix:**

The corrected comment is:

```go
// Strip newlines from inp
```

### **Why This Fix is Important:**

While this is a small typo, clarity and accuracy in comments are essential for maintainability and readability of the code. This fix ensures that the comment more accurately reflects its intended meaning, i.e., removing newlines **from** the input string, rather than **form**. Properly written comments can help future developers understand the code more easily.