### PR TITLE
typo Update main.go

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -33,7 +33,7 @@ const timestampFormat = "Mon 02 Jan 2006 3:04:05 PM MST"
 func validateSignedMessage(inp string) (*SignedMessage, error) {
 	var sm SignedMessage
 
-	// Strip newlines form inp
+	// Strip newlines from inp
 	inp = strings.ReplaceAll(inp, "\n", "")
 
 	err := json.Unmarshal([]byte(inp), &sm)


### PR DESCRIPTION
### Fix Typo in `validateSignedMessage` Function

**Description:**
This pull request addresses a minor typo in the `validateSignedMessage` function. The comment:
```go
// Strip newlines form inp
```
contains a misspelling of the word "form", which has been corrected to "from":
```go
// Strip newlines from inp
```

**Importance:**
While this typo does not affect the functionality of the code, it improves code readability and clarity. Clear and accurate comments help maintainers and contributors understand the intention behind the code, preventing any confusion in the future.