### PR TITLE
Fix Array Index Out of Bounds Issue in Encode Function

### DIFF
--- a/words/encode.go
+++ b/words/encode.go
@@ -4,7 +4,7 @@ package words
 func Encode(key []byte) []string {
 	out := make([]string, len(key))
 	for i, b := range key {
-		out[i] = words[i%2][b]
+		out[i] = words[i%2][b%256]
 	}
 	return out
 }


### PR DESCRIPTION
### Title:
Fix Array Index Out of Bounds Issue in `Encode` Function

### Description:
In the original implementation of the `Encode` function, there was a potential issue with array indexing. The byte values in the `key` slice could exceed 255, leading to an out-of-bounds error when accessing the `words[i%2][b]` array. To prevent this, I added a check to ensure that the byte value `b` is always within the valid range of 0-255 by using `b%256`.

This change ensures that the array indices remain within the bounds of the two word lists, preventing potential runtime errors and ensuring the robustness of the encoding process.

By applying this fix, we guarantee that the `Encode` function will handle any byte values safely, maintaining the integrity of the word list mapping and making the code more reliable in edge cases.

